### PR TITLE
Fix bug with component mounting after willEnter

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -59,13 +59,15 @@ export class TransitionGroup extends Component {
 	}
 
 	componentDidUpdate() {
-		let keysToEnter = this.keysToEnter;
-		this.keysToEnter = [];
-		keysToEnter.forEach(this.performEnter);
+		setTimeout(() => {
+			let keysToEnter = this.keysToEnter;
+			this.keysToEnter = [];
+			keysToEnter.forEach(this.performEnter);
 
-		let keysToLeave = this.keysToLeave;
-		this.keysToLeave = [];
-		keysToLeave.forEach(this.performLeave);
+			let keysToLeave = this.keysToLeave;
+			this.keysToLeave = [];
+			keysToLeave.forEach(this.performLeave);
+		});
 	}
 
 	performAppear(key) {


### PR DESCRIPTION
In preact@8, there is an odd issue where `comopnentDidMount()` gets fired _after_ `componentWillEnter`. I added a simple fix in this PR by just delaying the appear/leave functions, but perhaps somebody with more knowledge of preact@8 internals will know of a better solution.

Here is a test case that shows the fix, the console logs show the incorrect order of functions (enter -> mount), but after applying the patch they will show correct order (mount -> enter).

```js
import { h, render, Component } from 'preact';
import TransitionGroup from 'preact-transition-group';

class Test extends Component {
  componentDidMount () {
    console.log('did mount');
  }
  componentWillEnter (done) {
    console.log('did enter', done());
  }
  componentWillAppear (done) {
    console.log('did appear', done());
  }
}
class App extends Component {

  constructor () {
    super();
    this.state = { toggled: true };
  }

  componentDidMount () {
    window.addEventListener('click', () => {
      this.setState({ toggled: !this.state.toggled });
    });
  }
  render (_, { toggled }) {
    return <TransitionGroup>{toggled && <Test />}</TransitionGroup>;
  }
};

render(<App />, document.body);
```